### PR TITLE
moz-web-qa can get back on master/upstream

### DIFF
--- a/python-test-automation.md
+++ b/python-test-automation.md
@@ -121,7 +121,7 @@ Also:
     * [mechanize](https://pypi.python.org/pypi/mechanize/) - Stateful programmatic web browsing in Python.
 - frameworks and wrappers
     * [py.saunter](https://github.com/element-34/py.saunter) - An opinionated automation framework for use with the Selenium RC and WebDriver libraries.
-    * [moz-web-qa](https://github.com/davehunt/pytest-mozwebqa) - A plugin for py.test that provides additional features needed for Mozilla's WebQA projects.
+    * [moz-web-qa](https://github.com/mozilla/pytest-mozwebqa) - A plugin for py.test that provides additional features needed for Mozilla's WebQA projects.
     * [testutils sst](http://testutils.org/sst) - A web test framework that uses Python to generate functional browser-based tests.
     * [wtframework](https://github.com/wiredrive/wtframework) - Framework for configurable Web Tests in Python.
     * [holmium.core](https://github.com/alisaifee/holmium.core) - Page objects & Utilities for writing selenium test cases.


### PR DESCRIPTION
moz-web-qa can get back on master/upstream

This lib is actually discontinued - has been split up into about 4 smaller libs - but might as well update to link to the upstream where that notice is.