### PR TITLE
Adding selenium-to-restassured

### DIFF
--- a/java-test-automation.md
+++ b/java-test-automation.md
@@ -218,6 +218,7 @@ Also:
 * [AssertJ](https://joel-costigliola.github.io/assertj/) - Powerful fluent assertion framework. Compatible with any xUnit framework.
 * [Truth](https://truth.dev/) - Fluent assertion framework for Java and Android from Google.
 * [JSONassert](https://github.com/skyscreamer/JSONassert) - JSON assertion library.
+* [selenium-to-restassured](https://github.com/mwinteringham/selenium-to-restassured) - Adapter to easily share Selenium WebDriver cookies with Rest Assured back and forth with this Java api.
 
 ## Test Data
 * [Faker](https://github.com/DiUS/java-faker) - Java implementation of Faker, a library for generating fake data such as names, addresses, and phone numbers.


### PR DESCRIPTION
Adapter to easily share Selenium WebDriver cookies with Rest Assured back and forth with this Java api

https://github.com/mwinteringham/selenium-to-restassured