### PR TITLE
Fix broken link to Gauge.

### DIFF
--- a/general-purpose-test-automation-tools.md
+++ b/general-purpose-test-automation-tools.md
@@ -24,7 +24,7 @@ Also:
 ---
 
 ## Functional testing
-* [gauge](http://getgauge.io) Light weight cross-platform test automation
+* [gauge](https://gauge.org/) Lightweight cross-platform test automation.
 * [STAF](http://staf.sourceforge.net/) The Software Testing Automation Framework (STAF) is an open source, multi-platform, multi-language framework designed around the idea of reusable components, called services (such as process invocation, resource management, logging, and monitoring). STAF removes the tedium of building an automation infrastructure, thus enabling you to focus on building your automation solution. The STAF framework provides the foundation upon which to build higher level solutions, and provides a pluggable approach supported across a large variety of platforms and languages.
 * [Cerberus](https://github.com/cerberustesting/cerberus-source) is a low-code software testing automation enabling continuous testing at scale. The solution allows the collaboration of the teams from the use-cases definition to the test case execution on the variety of browsers, devices, apps and APIs. It supports various integrations for speed of implementation such as Jenkins, Bitbucket,  Slack, Kafka. It is available and maintained in open-source by various digital and retail players such as La Redoute, Decathlon, Adeo, Norauto.
 * [OpenTest](https://getopentest.org/) OpenTest is an open source functional test automation tool for web applications, mobile apps and REST APIs, maintained by McDonald's. OpenTest requires little to no coding skills but does provide the ability to seamlessly embed JavaScript code into the test logic to cater to complex scenarios.


### PR DESCRIPTION
getgauge.io is no longer a working domain. It appears https://gauge.org/ is the new home for this project.