### PR TITLE
Add graphql-to-karate to API Testing section

### DIFF
--- a/general-purpose-test-automation-tools.md
+++ b/general-purpose-test-automation-tools.md
@@ -56,6 +56,7 @@ Also:
 * [Insomnia](https://insomnia.rest/) provides workflows and tools to make API Development Easier.
 * [Apitest](https://github.com/sigoden/apitest) - Apitest is declarative api testing tool with JSON-like DSL for easy testing of REST services.
 * [vREST NG](https://vrest.io) is a zero code API automation solution for functional and regression testing of your APIs. It will help you to efficiently develop your test suites using record/replay, excel sheets (data driven testing) and allow you to derive your API testing using Swagger or OpenAPI specs.
+* [graphql-to-karate](https://github.com/wbaldoumas/graphql-to-karate) - `graphql-to-karate` automagically generates Karate API tests from your GraphQL schemas.
 
 ## Performance and load testing
 * [k6](https://github.com/loadimpact/k6) - Like unit testing, for performance. A modern load testing tool, using Go and JavaScript.


### PR DESCRIPTION
[graphql-to-karate](https://github.com/wbaldoumas/graphql-to-karate) is a command line tool that automatically generates [Karate](https://github.com/karatelabs/karate) API tests from GraphQL schemas. It is highly configurable, usable in both interactive and non-interactive mode, and supports most of the current GraphQL spec. 

See the demo [here](https://github.com/wbaldoumas/graphql-to-karate#-demonstration).