### PR TITLE
Fix URL of MacacaJS

### DIFF
--- a/javascript-test-automation.md
+++ b/javascript-test-automation.md
@@ -117,7 +117,7 @@ No dependencies, works with any unit testing framework.
 
 ## Mobile test automation
 * [WebdriverIO's Appium implementation](https://github.com/webdriverio/appium-boilerplate/) - nodejs bindings implemeting Appium commands.
-* [Macaca](https://macacajs.com/) - Solution for Automation Test with Ease. Both Mobile, Desktop Platforms Supported, native, Hybrid, Mobile Web Multi-applications Supported, Command line tools & CI Solution provided.
+* [Macaca](https://macacajs.github.io/) - Solution for Automation Test with Ease. Both Mobile, Desktop Platforms Supported, native, Hybrid, Mobile Web Multi-applications Supported, Command line tools & CI Solution provided.
 * [Detox](https://github.com/wix/Detox) - Gray Box End-to-End Testing and Automation Framework for Mobile Apps 
 * [Cavy](https://github.com/pixielabs/cavy) - Cavy is a cross-platform integration test framework for React Native, by Pixie Labs.
 


### PR DESCRIPTION
The current URL of MacacaJS is not working properly, they may switched to Github page as main page.