### PR TITLE
Fix broken links

### DIFF
--- a/automation-and-testing-as-service.md
+++ b/automation-and-testing-as-service.md
@@ -67,7 +67,7 @@ Also:
 ## Reporting
 * [Testomat.io](https://testomat.io/) - test management and reporting system for automated tests
 * [Browsershots](http://browsershots.org/) -  Makes screenshots of your web design in different browsers. It is a free open-source online service created by Johann C. Rocholl. When you submit your web address, it will be added to the job queue. A number of distributed computers will open your website in their browser. Then they will make screenshots and upload them to the central server here.
-* [Perfomatic](https://wiki.mozilla.org/Perfomatic) - Mozilla graph server is used to understand how multiple performance metrics change over time. It is a web application for creating graphs of performance test results for a user-configurable combination of branch, operating system and machine. [Example](http://graphs.mozilla.org/graph.html).
+* [Perfomatic](https://wiki.mozilla.org/Perfomatic) - Mozilla graph server is used to understand how multiple performance metrics change over time. It is a web application for creating graphs of performance test results for a user-configurable combination of branch, operating system and machine.
 
 # Resources
 Where to discover new libraries, information, tools, etc.

--- a/javascript-test-automation.md
+++ b/javascript-test-automation.md
@@ -154,14 +154,14 @@ No dependencies, works with any unit testing framework.
 
 ## Continuous Integration
 * [Strider CD](http://strider-cd.github.io/) - Open Source Continuous Deployment / Continuous Integration platform written in NodeJS.
-* [Gulp](http://gulpjs.com/) - Streaming building system/task runner in nodejs. Based on streaming data flow conception (https://github.com/substack/stream-handbook).
+* [Gulp](http://gulpjs.com/) - Streaming building system/task runner in nodejs.
 * [Grunt](https://gruntjs.com/) - Streaming building system/task runner in nodejs. Can't do anything without plugins, but there are many of them for all kinds of purposes.
 
 ## Reporting
 * [Testomat.io](https://testomat.io/) - test management and reporting system for javascript automated tests
 * [ReportPortal.io](http://ReportPortal.io) - powerfull results management and analytics for test automation reports. Powered with Machine Learning. Real-time integration and reports, visualization of trends and statistics, custom dashboards and widgets, gives you real visibility into the state of test automation. Integral part of CI/CD with TA and Continous Testing. Server-client application, can be used for any type of automated tests, with huge list of [available integrations](https://github.com/reportportal?utf8=✓&q=agent-). Free and OpenSourced, [GitHub link](https://github.com/reportportal).
 * [Istanbul](https://github.com/gotwarlost/istanbul) - JS coverage tool for unit tests, server side functional tests and browser tests.
-* [Blanket](http://blanketjs.org/) - JavaScript code coverage library that works both in-browser and with nodejs.
+* [Blanket](https://github.com/alex-seville/blanket) - JavaScript code coverage library that works both in-browser and with nodejs.
 * [Mochawesome](https://github.com/adamgruber/mochawesome) - reporter for Mocha that generates a full fledged HTML/CSS report that helps visualize your test suites
 * [Allure](http://allure.qatools.ru/) - a universal reporter for any testing framework. Supports [Mocha](https://docs.qameta.io/allure/2.0/#_mocha) and [Jasmine (and Protractor)](https://docs.qameta.io/allure/2.0/#_jasmine)
 * [cucumber-html-reporter](https://www.npmjs.com/package/cucumber-html-reporter) - Provide Cucumber JSON report file created from your framework and this module will create pretty HTML reports. Choose your best suitable HTML theme and dashboard on your CI with available HTML reporter plugins.
@@ -173,7 +173,7 @@ No dependencies, works with any unit testing framework.
 * [test-each](https://github.com/ehmicky/test-each) - Repeat tests using different inputs.
 
 ## Documentation generation
-* [JSdoc3](http://usejsdoc.org/) - An API documentation generator for JavaScript
+* [JSdoc3](https://jsdoc.app/) - An API documentation generator for JavaScript
 * [jsdoc-to-markdown](https://github.com/jsdoc2md/jsdoc-to-markdown) - Generates markdown API documentation from jsdoc annotated source code.
 * [Docco](http://jashkenas.github.io/docco/) - Docco is a quick-and-dirty documentation generator, written in Literate CoffeeScript
 * [MrDoc](https://mr-doc.github.io/mr-doc/) - A personal source documenter

--- a/mobile-test-automation.md
+++ b/mobile-test-automation.md
@@ -25,7 +25,7 @@ Also:
 * [Appium](http://appium.io/) - An open source test automation framework for use with native, hybrid and mobile web apps. It drives iOS and Android apps using the WebDriver protocol.
     * [Appium Desktop](https://github.com/appium/appium-desktop) - Appium Desktop is an open source app for Mac, Windows, and Linux which gives you the power of the Appium automation server in a beautiful and flexible UI.
 * [Winium.StoreApps](https://github.com/2gis/Winium.StoreApps/) - An open source test automation tool for Windows Store apps, tested on emulators. It is Selenium Remote WebDriver implementation.
-* [Macaca](https://macacajs.com/) - Solution for Automation Test with Ease. Both Mobile, Desktop Platforms Supported, native, Hybrid, Mobile Web Multi-applications Supported, Command line tools & CI Solution provided.
+* [Macaca](https://macacajs.github.io/) - Solution for Automation Test with Ease. Both Mobile, Desktop Platforms Supported, native, Hybrid, Mobile Web Multi-applications Supported, Command line tools & CI Solution provided.
 * [Katalon](https://www.katalon.com/) - An all-in-one test automation solution
 * [Mocking Star](https://github.com/Trendyol/mockingstar) - Network mocking tool designed to simplify the process of HTTP request mocking, network debugging, and using UI tests.
 

--- a/php-test-automation.md
+++ b/php-test-automation.md
@@ -39,7 +39,7 @@ Also:
 
 ## Mock frameworks
 
-* [php-vfs](http://thornag.github.io/php-vfs/) - Virtual filesystem provider
+* [php-vfs](https://github.com/adlawson/php-vfs) - Virtual filesystem provider
 * [adlawson/vfs](https://github.com/adlawson/php-vfs) - Another virtual filesystem provider
 * [vfsStream](https://github.com/mikey179/vfsStream) - A stream wrapper for a virtual file system that may be helpful in unit tests to mock the real file system. It can be used with any unit test framework, like PHPUnit or SimpleTest.
 * [Mockery](https://github.com/padraic/mockery) - Objects mocking and method call assertions framework
@@ -100,15 +100,13 @@ Also:
 ## Security checking
 
 * [SensioLabs Security Checker](https://github.com/sensiolabs/security-checker) - Command line tool that checks if 
-your application uses dependencies with known security vulnerabilities. It uses the [SensioLabs Security Check Web 
-service](http://security.sensiolabs.org/) and the [Security Advisories Database](https://github.com/FriendsOfPHP/security-advisories).
+your application uses dependencies with known security vulnerabilities. It uses the [Security Advisories Database](https://github.com/FriendsOfPHP/security-advisories).
 
 ## Continuous Integration
 
 * [PHPCI](https://www.phptesting.org/) - Free and open source continuous integration tool specifically designed for PHP.
 * [PHP Censor](https://github.com/php-censor/php-censor) - Open source self-hosted continuous integration server for PHP projects.
 * [Jenkins PHP project template](http://jenkins-php.org/) - The goal of this project is to provide a standard template for Jenkins jobs for PHP projects.
-* [Sismo](https://sismo.symfony.com/) - Unlike more "advanced" Continuous Integration Servers (like Jenkins), Sismo does not try to do more than getting your code, running your tests, and send you notifications.
 
 ## Reporting
 * [Testomat.io](https://testomat.io/) - test management and reporting system for php automated tests
@@ -131,7 +129,7 @@ and [PHPUnit](https://github.com/allure-framework/allure-phpunit).
 
 ## Useful libs
 
-* [PHP CS Fixer](http://cs.sensiolabs.org/) - tool for automatic convention violations correction
+* [PHP CS Fixer](https://cs.symfony.com/) - tool for automatic convention violations correction
 
 # Resources
 

--- a/python-test-automation.md
+++ b/python-test-automation.md
@@ -48,14 +48,14 @@ Also:
     * [proboscis](https://pythonhosted.org/proboscis/) -  is a Python test framework that extends Python’s built-in unittest module and Nose with features from TestNG.
     * [grail](https://github.com/wgnet/grail) - is a library which allows test script creation based on steps.
     * [testify](https://github.com/Yelp/Testify/) - unit test framework, provides Enhanced test fixture setup, Split test suites into buckets for easy parallelization, PEP8 naming conventions & Fancy color test runner with lots of logging / reporting option.
-    * [trial](http://twistedmatrix.com/trac/wiki/TwistedTrial) - Extension of unittest to support writing asynchronous unit tests using Deferreds and new result types ('skip' and 'todo'). Includes a command-line program that does test discovery and integrates with doctest and coverage.
+    * [trial](https://docs.twistedmatrix.com/en/stable/api/twisted.trial.html) - Extension of unittest to support writing asynchronous unit tests using Deferreds and new result types ('skip' and 'todo'). Includes a command-line program that does test discovery and integrates with doctest and coverage.
     * [subunit](https://launchpad.net/subunit) - Transparently adds support for running unittest test cases/suites in a separate process : prevents system wide changes by a test destabilising the test runner. It also allows reporting from tests in another process into the unittest framework, giving a single integrated test environment.
     * [testresources](https://launchpad.net/testresources) - Provides a mechanism for managing 'resources' - expensive bits of infrastructure - that are needed by multiple tests. Resources are constructed and free on demand, but with an optional TestSuite?, the test run order is optimised to reduce the number of resource constructions and releases needed. Compatible with unittest.
     * [testtools](https://launchpad.net/testtools) - Useful extensions to unittest derived from custom extensions by projects such as Twisted and Bazaar.
     * [Sancho](https://www.mems-exchange.org/software/DurusWorks/) - Sancho 2.1 runs tests, and provides output for tests that fail; Sancho 2.1 does not count tests passed or failed; targets projects that do not maintain failing tests
     * [zope.testing](https://pypi.python.org/pypi/zope.testing) - Powerful test runner that includes support for post-mortem debugging of test failures. Also includes profiling and coverage reporting. This is a standalone package that has no dependencies on Zope and works just fine with projects that don't use Zope.
     * [pythoscope](http://pythoscope.org/) - Tool that will automatically, or semi-automatically, generate unit tests for legacy systems written in Python.
-    * [testlib](http://www.logilab.org/project/logilab-common/) - Gives more power to standard unittest. More assert* methods; support for module level setup/teardown; skip test feature...
+    * [testlib](https://logilab-common.readthedocs.io/en/latest/) - Gives more power to standard unittest. More assert* methods; support for module level setup/teardown; skip test feature...
     * [dutest](https://pypi.python.org/pypi/dutest) - An object oriented interface to retrieve unittest test cases out of doctests. Hides initialization from doctests by allowing setUp and tearDown for each interactive example. Allows control over all the options provided by doctest. Specialized classes allow selective test discovery across a package hierarchy.
     * [green](https://github.com/CleanCut/green) - Green is a clean, colorful test runner for Python unit tests. Compare it to nose or trial.
     * [ddt](https://github.com/txels/ddt) - Data-Driven tests with unittest
@@ -89,7 +89,7 @@ Also:
     * [responses](https://github.com/dropbox/responses) - A utility library for mocking out the requests Python library.
     * [doublex](https://pypi.python.org/pypi/doublex) - Powerful test doubles framework for Python.
     * [freezegun](https://github.com/spulec/freezegun) - Travel through time by mocking the datetime module.
-    * [httpretty](http://falcao.it/HTTPretty/) - HTTP request mock tool for Python.
+    * [httpretty](https://github.com/gabrielfalcao/HTTPretty) - HTTP request mock tool for Python.
     * [httmock](https://github.com/patrys/httmock) - A mocking library for requests for Python 2.6+ and 3.2+.
     * [pretenders](https://github.com/pretenders/pretenders) - fake servers for testing.
     * [mock-server](https://github.com/tomashanacek/mock-server) - Simple mock server for REST and XML-RPC API with admin panel based on tornado.
@@ -102,7 +102,7 @@ Also:
 
 ## Test Data manipulation
 
-* [faker](http://www.joke2k.net/faker/) - A Python package that generates fake data.
+* [faker](https://github.com/joke2k/faker) - A Python package that generates fake data.
 * [fake2db](https://github.com/emirozer/fake2db) - Fake database generator.
 * [ForgeryPy](https://pypi.python.org/pypi/ForgeryPy) - An easy to use forged data generator for Python. It's a port of forgery.
 * [radar](https://pypi.python.org/pypi/radar) - Generate random datetime / time.
@@ -144,7 +144,7 @@ Also:
     * [gocept.selenium](https://pypi.python.org/pypi/gocept.selenium) - An API for the Selenium remote control that is suited for writing tests and integrates this with your test suite for any WSGI, Plone, Zope 2, ZTK, or Grok application.
     * [webium](https://github.com/wgnet/webium) - A Page Object pattern implementation library for Python
     * [robotframework-anywherelibrary](https://github.com/luisxiaomai/robotframework-anywherelibrary) - A cross platform(desktop browser,android,ios) testing library for Robot Framework that leverages the Selenium 2(WebDriver) libraries internally to control a web browser and appium as mobile test automation framework for use with native and hybrid app.
-    * [robotframework-pageobjects](https://github.com/ncbi/robotframework-pageobjects) - Nice implementation of the Page Object pattern with robotframework and selenium, that can work even outside of robotframework. More on this [blog post](http://kahunacohen.com/2014/12/03/new-testing-paradigm-robotframework-pageobjects/)
+    * [robotframework-pageobjects](https://github.com/ncbi/robotframework-pageobjects) - Nice implementation of the Page Object pattern with robotframework and selenium, that can work even outside of robotframework.
     * [elementium](https://github.com/actmd/elementium) - jQuery-style syntactic sugar for highly reliable automated browser testing in Python
     * [slickqa](http://www.slickqa.com/webdriver/python/) - The slick-webdriver-python project is a wrapper around the python webdriver client bindings.
     * [selene](https://github.com/yashaka/selene/) - Concise UI tests in Python + Ajax support + PageObjects + Widgets
@@ -190,7 +190,7 @@ Also:
 * [robotframework-autoitlibrary](https://code.google.com/p/robotframework-autoitlibrary/) - A Windows GUI testing library for Robot Framework
 * [autopy](https://github.com/msanders/autopy) - A simple, cross-platform GUI automation toolkit for Python.
 * [UISoup](https://pypi.python.org/pypi/UISoup/) - This library supports UI-related testing using Python on Windows and Mac OS. (Only Python x86 is supported)
-* [pywinauto](http://pywinauto.github.io/) - Very pythonic object-oriented Windows GUI automation library. Now it supports 64-bit Py2 and Py3.
+* [pywinauto](https://pywinauto.readthedocs.io/en/latest/) - Very pythonic object-oriented Windows GUI automation library. Now it supports 64-bit Py2 and Py3.
 * [SikuliX](http://sikulix.com/) - OpenCV based GUI test framework that uses image recognision to locate item to interact with, script from python 2.7.
 * [AutoItDriverServer](https://github.com/daluu/AutoItDriverServer) - Selenium server to control/drive AutoIt via (Remote)WebDriver API.
 
@@ -210,7 +210,7 @@ Also:
 
 * [Rester](https://github.com/chitamoor/rester) - Framework for testing (RESTful) HTTP APIs
 * [pyresttest](https://github.com/svanoort/pyresttest) - A REST testing and API microbenchmarking tool
-* [siesta](http://scastillo.github.com/siesta) - Python REST Client
+* [siesta](https://github.com/scastillo/siesta) - Python REST Client
 * [play_requests](https://github.com/davidemoro/play_requests) - [pytest-play](https://github.com/pytest-dev/pytest-play) plugin driving the famous python requests library for making HTTP calls using plain YAML files
 * [gabbi](https://github.com/cdent/gabbi) - a tool for running HTTP tests where requests and responses are expressed as declarations in YAML files.
 * [Schemathesis](https://github.com/kiwicom/schemathesis) - Schemathesis is a tool for property-based testing of applications based on Open API & Swagger specs. It reads the application schema and generates test cases which will ensure that your application is compliant with its schema. Includes `pytest` & `unittest` integrations.
@@ -272,7 +272,7 @@ Also:
 
 * [Sphinx](http://sphinx-doc.org/) - Python Documentation generator.
 * [MkDocs](http://www.mkdocs.org/) - Markdown friendly documentation generator.
-* [Pycco](http://fitzgen.github.io/pycco/) - The original quick-and-dirty, hundred-line-long, literate-programming-style documentation generator.
+* [Pycco](https://pycco-docs.github.io/pycco/) - The original quick-and-dirty, hundred-line-long, literate-programming-style documentation generator.
 
 ## Editors, IDE, consoles
 
@@ -300,7 +300,7 @@ Libraries that may help you to build better test automation.
 * [python-tesseract](https://code.google.com/p/python-tesseract/) - Wrapper class for tesseract OCR (Linux & Mac & Windows)
 * [pywinrm](https://github.com/diyan/pywinrm/) - A Python client for Windows Remote Management (WinRM). This allows you to invoke commands on target Windows machines from any machine that can run Python. WinRM allows you to call native objects in Windows. These include, but are not limited to, running batch scripts, powershell scripts and fetching WMI variables. For more information on WinRM, please visit Microsoft's WinRM site.
 * [fig](http://www.fig.sh/) - Fast, isolated development environments using [Docker](https://www.docker.com/).
-* [gitapi](http://bitbucket.org/haard/gitapi) - Pure-Python API for git.
+* [gitpython](https://gitpython.readthedocs.io/en/stable/intro.html) - GitPython is a python library used to interact with git repositories, high-level like git-porcelain, or low-level like git-plumbing..
 * [Pyro4](https://github.com/irmen/Pyro4) - Pyro enables you to build applications in which objects can talk to each other over the network, with minimal programming effort.
 * [keyboard](https://github.com/boppreh/keyboard) - Hook and simulate global keyboard events on Windows and Linux.
 * [Errbot](http://errbot.io/en/latest/) - Errbot is a chatbot, a daemon that connects to your favorite chat service and brings your tools into the conversation.
@@ -311,7 +311,7 @@ Libraries that may help you to build better test automation.
 * [Spyne](http://spyne.io/) - Spyne is a Python RPC toolkit that makes it easy to expose online services that have a well-defined API using multiple protocols and transports.
 * [Pexpect](https://pexpect.readthedocs.io/en/stable/) - Pexpect makes Python a better tool for controlling other applications.
 * [devtools-proxy](https://github.com/bayandin/devtools-proxy) - Proxy for Chrome DevTools. Fully compatible with Selenium and ChromeDriver
-* [extratools](https://www.chuancong.site/extratools/) - 145+ extra higher-level functional tools that go beyond standard library’s itertools, functools, etc. and popular third-party libraries like toolz, fancy, and more-itertools.
+* [extratools](https://github.com/chuanconggao/extratools) - 145+ extra higher-level functional tools that go beyond standard library’s itertools, functools, etc. and popular third-party libraries like toolz, fancy, and more-itertools.
 * [retrying](https://github.com/rholder/retrying) - Retrying is an Apache 2.0 licensed general-purpose retrying library, written in Python, to simplify the task of adding retry behavior to just about anything. 
 * [mitmproxy](https://mitmproxy.org/) - mitmproxy is a free and open source interactive HTTPS proxy. 
 * [Python MSS](https://github.com/BoboTiG/python-mss) - An ultra fast cross-platform multiple screenshots module in pure Python using ctypes. 

--- a/ruby-test-automation.md
+++ b/ruby-test-automation.md
@@ -42,7 +42,7 @@ Also:
     * [RR](https://github.com/rr/rr) - A test double framework that features a rich selection of double techniques and a terse syntax.
 - BDD
     * [RSpec](http://rspec.info/) - Behaviour Driven Development for Ruby. RSpec becomes available in Ruby projects on attaching the rspec gem. For the Rails applications, rspec-rails gem is also required.
-    * [Cucumber](http://cukes.info/) - This testing tool supports BDD, and enables using features and scenarios written in a human-readable language, either English or any other language specified in the # language: comment. Cucumber becomes available in project upon installing and activating the cucumber gem.
+    * [Cucumber](https://github.com/cucumber/cucumber-ruby) - This testing tool supports BDD, and enables using features and scenarios written in a human-readable language, either English or any other language specified in the # language: comment. Cucumber becomes available in project upon installing and activating the cucumber gem.
     * [Bacon](https://github.com/chneukirchen/bacon) - A small RSpec clone.
     * [minitest](https://github.com/seattlerb/minitest) - minitest provides a complete suite of testing facilities supporting TDD, BDD, mocking, and benchmarking.
     * [Spinach](https://github.com/codegram/spinach) - Spinach is a high-level BDD framework that leverages the expressive Gherkin language (used by Cucumber) to help you define executable specifications of your application or library's acceptance criteria.
@@ -79,7 +79,7 @@ Also:
 ## Web UI test automation
 
 - libraries
-    * [Selenium WebDriver](http://selenium.googlecode.com/git/docs/api/rb/index.html) - This gem provides Ruby bindings for WebDriver.
+    * [Selenium WebDriver](https://www.selenium.dev/documentation/) - This gem provides Ruby bindings for WebDriver.
     * [API Taster](https://github.com/fredwu/api_taster) - A quick and easy way to visually test your Rails application's API.
     * [Watir](https://github.com/watir/watir/) - Web application testing in Ruby.
     * [Watir-webdriver](http://watirwebdriver.com/) - The most elegant way to use WebDriver with ruby.
@@ -90,7 +90,7 @@ Also:
 - frameworks
     * [Capybara](https://github.com/teamcapybara/capybara) - Acceptance test framework for web applications.
     * [Konacha](https://github.com/jfirebaugh/konacha) - Test your Rails application's JavaScript with the mocha test framework and chai assertion library.
-    * [chemistrykit](https://github.com/chemistrykit/chemistrykit) - Simple and opinionated web testing framework for Selenium WebDriver that follows convention over configuration and integrates with SauceLabs for cross-browser execution in the cloud.
+    * [chemistrykit](https://www.rubydoc.info/gems/chemistrykit/3.10.1) - Simple and opinionated web testing framework for Selenium WebDriver that follows convention over configuration and integrates with SauceLabs for cross-browser execution in the cloud.
     * [howitzer](https://github.com/strongqa/howitzer) - is a Ruby-based framework for acceptance testing. It was originally developed for testing web applications, but you can also use it for API testing and web service testing.The framework was built with modern patterns, techniques, and tools in automated testing.
 - page objects
     * [page-object](https://github.com/cheezy/page-object) - Gem to implement PageObject pattern in watir-webdriver and selenium-webdriver.
@@ -122,13 +122,9 @@ Also:
 ## Virtual environments
 
 * [RVM](https://rvm.io/) - Ruby Version Manager (RVM) is a unix command-line tool which allows you to easily install, manage, and work with multiple ruby environments from interpreters to sets of gems.
-* [Pik](http://rubyinstaller.org/add-ons/pik/) - Multi-Ruby Manager for Windows.
+* [Pik](https://github.com/vertiginous/pik) - Multi-Ruby Manager for Windows.
 * [rbenv](http://rbenv.org/) - Use rbenv to pick a Ruby version for your application and guarantee that your development environment matches production.
-* [asdf-vm](https://asdf-vm.com/) - Manage multiple runtime versions with a single CLI tool, for Node.js, Ruby, Python, Elixir 
-
-## Performance & stress & load
-
-* [Yandex.Tank](https://yandex.ru/dev/tank/) - Yandex.Tank is a tool for performing load testing and analyzing the performance of web services and applications
+* [asdf-vm](https://asdf-vm.com/) - Manage multiple runtime versions with a single CLI tool, for Node.js, Ruby, Python, Elixir
 
 ## Security checking
 


### PR DESCRIPTION
Pull request solves the problem from issue [#485](https://github.com/atinfo/awesome-test-automation/issues/467)

## Automation and testing

Removed:
1. Scan My Server. Official site is not available. Could not find new address or derivative product.
2. Example link in Mozilla Perfomatic. Page was removed from documentation
Updated:
1. Gulp. Broken link to substack repository removed

## JavaScript test automation

Updated:
1. Blanket. Link updated
2. JSdoc3. Link updated

## General purpose test automation tools

Removed:
1. HP Unified Functional Testing (UFT), formerly known as (QTP). Product is closed

## Mobile, Tablet, TV test automation

Updated:
1. Macaca. Link updated

## PHP test automation

Updated:
1. php-vfs. Link updated

Removed:
1. Sismo. This repository has been archived by the owner on Feb 1, 2021

## Python test automation

Updated:
1. Trial. Updated link
2. Httpretty. Updated link
3. Pycco. Updated link
4. Siesta. Updated link
5. Pywinauto. Updated link
6. Robotframework-pageobjects. Updated link
7. Faker. Updated link
8. GitAPI. Replaced with GitPython
9. Extratools. Updated link

Removed:
1. Pages. Product is closed

## Ruby test automation

Updated:
1. Cucumber. Updated link
2. Selenium WebDriver. Updated link

Removed:
1. Yandex Tank. Has been moved to Python 3