### PR TITLE
Add Caqui and Guara testing tools

### DIFF
--- a/automation-and-testing-as-service.md
+++ b/automation-and-testing-as-service.md
@@ -37,6 +37,8 @@ Also:
 * [endtest.io](https://endtest.io/) - Endtest is the leading test automation vendor providing a complete software platform to help organizations efficiently build automated end-to-end tests for Web and Mobile Applications.
 * [testsigma.com](https://testsigma.com/) A powerful open source end-to-end test automation platform for web Apps, mobile apps, and APIs to build stable and reliable tests quickly @DevOps speed. 
 * [DoesQA](https://does.qa/) Codeless test automation with a simple, intuitive drag-and-drop user interface. Run your tests on multiple browsers, emulated devices and with full concurrency as standard.
+* [Caqui](https://douglasdcm.github.io/caqui/) Caqui executes commands against Drivers synchronously and asynchronously. The intention is that the user does not worry about which Driver they're using. It can be WebDrivers like Selenium, MobileDrivers like Appium, or DesktopDrivers like Winium.
+* [Guara](https://guara.readthedocs.io/en/latest/) Guará is a Python framework designed to simplify UI test automation. Inspired by design patterns like Page Objects, App Actions, and Screenplay, Guará focuses on Page Transactions—encapsulating user interactions (transactions) on web pages, such as Login, Logout, or Form Submissions. It’s not just a tool; it’s a programming pattern that can be adapted to any web driver.
 
 ## API test automation and testing
 * [MockLab](http://get.mocklab.io?utm_source=awesome-test-automation&utm_medium=automation-and-testing-as-service) is a hosted API simulation tool built on WireMock (maintaining 100% API compatibility). It supports flexible request/response stubbing for any HTTP-based protocol, response templating with Handlebars, conditional proxying and fault injection.


### PR DESCRIPTION
Hi, I'm including Caqui and Guara testing tools to the list.
- Caqui is tool for test web UI pages like Selenium and Arsenic, but it can be executed asynchronously.
- Guara is the Python implementation of the Page Transactions Pattern that has the intent to help testers to better organize test cases.